### PR TITLE
Fixed Aspect Tooltip Rendering

### DIFF
--- a/src/main/java/dev/overgrown/thaumaturge/client/tooltip/AspectTooltipComponent.java
+++ b/src/main/java/dev/overgrown/thaumaturge/client/tooltip/AspectTooltipComponent.java
@@ -3,6 +3,7 @@ package dev.overgrown.thaumaturge.client.tooltip;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.util.Identifier;
 import java.util.Map;
 
@@ -35,8 +36,8 @@ public class AspectTooltipComponent implements TooltipComponent {
             int value = entry.getValue();
 
             // Draw aspect icon
-            Identifier texture = new Identifier(aspectId.getNamespace(), "textures/aspects_icons/" + aspectId.getPath() + ".png");
-            context.drawTexture(texture, currentX, y, 0, 0, 0, 16, 16, 16, 16);
+            Identifier texture = Identifier.of(aspectId.getNamespace(), "textures/aspects_icons/" + aspectId.getPath() + ".png");
+            context.drawTexture(RenderLayer::getGuiTextured, texture, currentX, y, 0, 0, 16, 16, 16, 16);
 
             // Draw value text
             String valueStr = String.valueOf(value);

--- a/src/main/java/dev/overgrown/thaumaturge/component/AspectComponent.java
+++ b/src/main/java/dev/overgrown/thaumaturge/component/AspectComponent.java
@@ -43,7 +43,7 @@ public final class AspectComponent {
             .build();
     public static final AspectComponent DEFAULT = new AspectComponent(Map.of());
 
-    private final Map<Identifier, Integer> aspects;
+    public final Map<Identifier, Integer> aspects;
 
     public AspectComponent(Map<Identifier, Integer> aspects) {
         this.aspects = Map.copyOf(aspects);

--- a/src/main/java/dev/overgrown/thaumaturge/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/overgrown/thaumaturge/mixin/ItemStackMixin.java
@@ -16,8 +16,8 @@ public abstract class ItemStackMixin {
 	private void addAspectTooltipData(CallbackInfoReturnable<Optional<TooltipData>> cir) {
 		ItemStack stack = (ItemStack) (Object) this;
 		AspectComponent component = AspectComponent.getOrDefault(stack);
-		if (component != null && !component.aspects().isEmpty()) {
-			cir.setReturnValue(Optional.of(new AspectTooltipData(component.aspects())));
+		if (component != null && !component.aspects.isEmpty()) {
+			cir.setReturnValue(Optional.of(new AspectTooltipData(component.aspects)));
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes the aspect rendering in the tooltips by making the aspects Map public, fixing some minor syntax issues, and correcting the Identifier and drawTexture lines to suit 1.21.4