### PR TITLE
Tweak the implementation of the `aspect` component and fix issues with the Apophenia item

### DIFF
--- a/src/main/java/dev/overgrown/thaumaturge/Thaumaturge.java
+++ b/src/main/java/dev/overgrown/thaumaturge/Thaumaturge.java
@@ -11,6 +11,7 @@ import dev.overgrown.thaumaturge.data.ModRegistries;
 import dev.overgrown.thaumaturge.item.ModItemGroups;
 import dev.overgrown.thaumaturge.item.ModItems;
 import dev.overgrown.thaumaturge.networking.SyncAspectIdentifierPacket;
+import dev.overgrown.thaumaturge.predicate.component.ModComponentPredicateTypes;
 import dev.overgrown.thaumaturge.recipe.Recipe;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -41,6 +42,7 @@ public class Thaumaturge implements ModInitializer {
 		ModBlocks.register();
 		ModItemGroups.register();
 		ModComponents.register();
+		ModComponentPredicateTypes.register();
 		registerRecipes();
 		ModBlockEntities.register();
 

--- a/src/main/java/dev/overgrown/thaumaturge/block/vessel/VesselBlock.java
+++ b/src/main/java/dev/overgrown/thaumaturge/block/vessel/VesselBlock.java
@@ -1,6 +1,7 @@
 package dev.overgrown.thaumaturge.block.vessel;
 
 import dev.overgrown.thaumaturge.component.AspectComponent;
+import dev.overgrown.thaumaturge.component.ModComponents;
 import dev.overgrown.thaumaturge.data.Aspect;
 import dev.overgrown.thaumaturge.recipe.Recipe;
 import dev.overgrown.thaumaturge.recipe.RecipeManager;
@@ -9,7 +10,6 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -152,7 +152,7 @@ public class VesselBlock extends Block implements BlockEntityProvider {
 
         AspectComponent totalAspects = new AspectComponent(new Object2IntOpenHashMap<>());
         for (ItemStack itemStack : blockEntity.getItems()) {
-            AspectComponent component = itemStack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+            AspectComponent component = itemStack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
             totalAspects.addAspect(component);
         }
 
@@ -181,7 +181,7 @@ public class VesselBlock extends Block implements BlockEntityProvider {
             ItemStack stack = blockEntity.getStack(i);
             if (stack.isEmpty()) continue;
 
-            AspectComponent component = stack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+            AspectComponent component = stack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
             Object2IntOpenHashMap<RegistryEntry<Aspect>> aspects = new Object2IntOpenHashMap<>(component.getMap());
 
             boolean modified = false;
@@ -203,7 +203,7 @@ public class VesselBlock extends Block implements BlockEntityProvider {
 
             if (modified) {
                 ItemStack newStack = stack.copy();
-                newStack.set(AspectComponent.TYPE, new AspectComponent(aspects));
+                newStack.set(ModComponents.ASPECT, new AspectComponent(aspects));
                 blockEntity.setStack(i, newStack);
             }
 
@@ -215,7 +215,7 @@ public class VesselBlock extends Block implements BlockEntityProvider {
         // Remove empty aspect items by iterating backwards to avoid index issues
         for (int i = blockEntity.size() - 1; i >= 0; i--) {
             ItemStack stack = blockEntity.getStack(i);
-            AspectComponent component = stack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+            AspectComponent component = stack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
             if (component.getMap().isEmpty()) {
                 blockEntity.removeStack(i);
             }

--- a/src/main/java/dev/overgrown/thaumaturge/component/AspectComponent.java
+++ b/src/main/java/dev/overgrown/thaumaturge/component/AspectComponent.java
@@ -5,7 +5,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.overgrown.thaumaturge.data.Aspect;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import net.minecraft.component.ComponentType;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
@@ -45,11 +44,6 @@ public class AspectComponent {
             component -> component.aspects,
             AspectComponent::new
     );
-
-    public static final ComponentType<AspectComponent> TYPE = ComponentType.<AspectComponent>builder()
-            .codec(CODEC)
-            .packetCodec(PACKET_CODEC)
-            .build();
 
     // Internal storage for aspects and their levels
     private final Object2IntOpenHashMap<RegistryEntry<Aspect>> aspects;

--- a/src/main/java/dev/overgrown/thaumaturge/component/BookStateComponent.java
+++ b/src/main/java/dev/overgrown/thaumaturge/component/BookStateComponent.java
@@ -1,0 +1,36 @@
+package dev.overgrown.thaumaturge.component;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+
+/**
+ * 	This component stores the state of a book. You can add more properties to this record, but currently, it only stores
+ * 	the following properties:
+ *
+ * 	@param open determines if the book is open.
+ */
+public record BookStateComponent(boolean open) {
+
+	//	The codec for this component. Uses the record codec builder for future-proofing (in case you need to add more
+	//	states)
+	public static final Codec<BookStateComponent> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+		Codec.BOOL.fieldOf("open").forGetter(BookStateComponent::open)
+	).apply(instance, BookStateComponent::new));
+
+	//	The packet codec for this component; used for syncing the properties of this component to the client
+	public static final PacketCodec<ByteBuf, BookStateComponent> PACKET_CODEC = PacketCodec.tuple(
+		PacketCodecs.BOOLEAN, BookStateComponent::open,
+		BookStateComponent::new
+	);
+
+	public static final BookStateComponent DEFAULT = new BookStateComponent(false);
+
+	//	Toggles the "open" state of this component
+	public BookStateComponent toggle() {
+		return new BookStateComponent(!this.open());
+	}
+
+}

--- a/src/main/java/dev/overgrown/thaumaturge/component/ModComponents.java
+++ b/src/main/java/dev/overgrown/thaumaturge/component/ModComponents.java
@@ -2,17 +2,27 @@ package dev.overgrown.thaumaturge.component;
 
 import dev.overgrown.thaumaturge.Thaumaturge;
 import net.minecraft.component.ComponentType;
-import net.minecraft.component.type.NbtComponent;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 
+import java.util.function.UnaryOperator;
+
 public class ModComponents {
-    public static final ComponentType<NbtComponent> BOOK_STATE = ComponentType.<NbtComponent>builder()
-            .codec(NbtComponent.CODEC)
-            .build();
+
+    public static final ComponentType<BookStateComponent> BOOK_STATE = register("book_state", builder -> builder
+        .codec(BookStateComponent.CODEC)
+        .packetCodec(BookStateComponent.PACKET_CODEC));
+
+    public static final ComponentType<AspectComponent> ASPECT = register("aspects", builder -> builder
+        .codec(AspectComponent.CODEC)
+        .packetCodec(AspectComponent.PACKET_CODEC));
 
     public static void register() {
-        Registry.register(Registries.DATA_COMPONENT_TYPE, Thaumaturge.identifier("aspects"), AspectComponent.TYPE);
-        Registry.register(Registries.DATA_COMPONENT_TYPE, Thaumaturge.identifier("book_state"), BOOK_STATE);
+
     }
+
+    private static <T> ComponentType<T> register(String path, UnaryOperator<ComponentType.Builder<T>> operator) {
+        return Registry.register(Registries.DATA_COMPONENT_TYPE, Thaumaturge.identifier(path), operator.apply(new ComponentType.Builder<>()).build());
+    }
+
 }

--- a/src/main/java/dev/overgrown/thaumaturge/item/AethericGoggles/AethericGogglesRenderer.java
+++ b/src/main/java/dev/overgrown/thaumaturge/item/AethericGoggles/AethericGogglesRenderer.java
@@ -4,6 +4,7 @@ import dev.overgrown.thaumaturge.Thaumaturge;
 import dev.overgrown.thaumaturge.client.tooltip.AspectTooltipComponent;
 import dev.overgrown.thaumaturge.client.tooltip.AspectTooltipData;
 import dev.overgrown.thaumaturge.component.AspectComponent;
+import dev.overgrown.thaumaturge.component.ModComponents;
 import dev.overgrown.thaumaturge.data.Aspect;
 import dev.overgrown.thaumaturge.item.ModItems;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -30,9 +31,6 @@ import net.minecraft.inventory.Inventory;
 import net.minecraft.block.entity.LootableContainerBlockEntity;
 import org.joml.Matrix4f;
 import org.joml.Vector2f;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Environment(EnvType.CLIENT)
 public class AethericGogglesRenderer {
@@ -81,13 +79,13 @@ public class AethericGogglesRenderer {
                 Entity entity = ((EntityHitResult) hit).getEntity();
                 if (entity instanceof ItemEntity itemEntity) {
                     ItemStack stack = itemEntity.getStack();
-                    currentAspects = stack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+                    currentAspects = stack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
                     tooltipPosition = calculateScreenPosition();
                 } else if (entity instanceof LivingEntity livingEntity) {
                     Object2IntOpenHashMap<RegistryEntry<Aspect>> combinedAspects = new Object2IntOpenHashMap<>();
                     for (EquipmentSlot slot : EquipmentSlot.values()) {
                         ItemStack stack = livingEntity.getEquippedStack(slot);
-                        AspectComponent component = stack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+                        AspectComponent component = stack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
                         component.getMap().forEach((aspect, count) ->
                                 combinedAspects.mergeInt(aspect, count, Integer::sum)
                         );
@@ -118,7 +116,7 @@ public class AethericGogglesRenderer {
                         ItemStack stack = container.getStack(i);
                         if (!stack.isEmpty()) {
                             hasItems = true;
-                            AspectComponent component = stack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+                            AspectComponent component = stack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
                             component.getMap().forEach((aspect, count) ->
                                     combinedAspects.mergeInt(aspect, count, Integer::sum)
                             );
@@ -130,7 +128,7 @@ public class AethericGogglesRenderer {
                     } else {
                         // Fallback to block's aspects
                         ItemStack blockStack = client.world.getBlockState(pos).getBlock().asItem().getDefaultStack();
-                        currentAspects = blockStack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+                        currentAspects = blockStack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
                     }
                 } else if (blockEntity instanceof Inventory inventory) {
                     // Original inventory handling for other containers
@@ -141,7 +139,7 @@ public class AethericGogglesRenderer {
                         ItemStack stack = inventory.getStack(i);
                         if (!stack.isEmpty()) {
                             hasItems = true;
-                            AspectComponent component = stack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+                            AspectComponent component = stack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
                             component.getMap().forEach((aspect, count) ->
                                     combinedAspects.mergeInt(aspect, count, Integer::sum)
                             );
@@ -150,11 +148,11 @@ public class AethericGogglesRenderer {
 
                     currentAspects = hasItems
                             ? new AspectComponent(combinedAspects)
-                            : client.world.getBlockState(pos).getBlock().asItem().getDefaultStack().getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+                            : client.world.getBlockState(pos).getBlock().asItem().getDefaultStack().getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
                 } else {
                     // Default block aspects
                     ItemStack blockStack = client.world.getBlockState(pos).getBlock().asItem().getDefaultStack();
-                    currentAspects = blockStack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+                    currentAspects = blockStack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
                 }
 
                 tooltipPosition = calculateScreenPosition();

--- a/src/main/java/dev/overgrown/thaumaturge/item/ModItems.java
+++ b/src/main/java/dev/overgrown/thaumaturge/item/ModItems.java
@@ -1,14 +1,13 @@
 package dev.overgrown.thaumaturge.item;
 
 import dev.overgrown.thaumaturge.Thaumaturge;
+import dev.overgrown.thaumaturge.component.BookStateComponent;
 import dev.overgrown.thaumaturge.component.ModComponents;
 import dev.overgrown.thaumaturge.utils.ItemBuilder;
 import dev.overgrown.thaumaturge.item.apophenia.Apophenia;
-import net.minecraft.component.type.NbtComponent;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroups;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.Rarity;
 
 public class ModItems {
@@ -72,7 +71,7 @@ public class ModItems {
             .withSettings(new Item.Settings()
                     .maxCount(1)
                     .rarity(Rarity.EPIC)
-                    .component(ModComponents.BOOK_STATE, NbtComponent.of(new NbtCompound()))
+                    .component(ModComponents.BOOK_STATE, BookStateComponent.DEFAULT)
             )
             .buildAndRegister(Apophenia::new);
 

--- a/src/main/java/dev/overgrown/thaumaturge/mixin/ItemMixin.java
+++ b/src/main/java/dev/overgrown/thaumaturge/mixin/ItemMixin.java
@@ -1,6 +1,7 @@
 package dev.overgrown.thaumaturge.mixin;
 
 import dev.overgrown.thaumaturge.component.AspectComponent;
+import dev.overgrown.thaumaturge.component.ModComponents;
 import dev.overgrown.thaumaturge.data.ItemAspectRegistry;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.component.ComponentMap;
@@ -33,7 +34,7 @@ public abstract class ItemMixin {
      */
     @Inject(method = "getComponents", at = @At("RETURN"), cancellable = true)
     private void getWithAspects(CallbackInfoReturnable<ComponentMap> cir) {
-        if(cir.getReturnValue().contains(AspectComponent.TYPE)) return;
+        if(cir.getReturnValue().contains(ModComponents.ASPECT)) return;
 
         ComponentMap.Builder builder = ComponentMap.builder();
         builder.addAll(cir.getReturnValue());
@@ -57,7 +58,7 @@ public abstract class ItemMixin {
 
         }
 
-        builder.add(AspectComponent.TYPE, aspectComponent);
+        builder.add(ModComponents.ASPECT, aspectComponent);
 
         cir.setReturnValue(builder.build());
     }

--- a/src/main/java/dev/overgrown/thaumaturge/mixin/client/ItemStackClientMixin.java
+++ b/src/main/java/dev/overgrown/thaumaturge/mixin/client/ItemStackClientMixin.java
@@ -2,7 +2,10 @@ package dev.overgrown.thaumaturge.mixin.client;
 
 import dev.overgrown.thaumaturge.component.AspectComponent;
 import dev.overgrown.thaumaturge.client.tooltip.AspectTooltipData;
+import dev.overgrown.thaumaturge.component.ModComponents;
 import dev.overgrown.thaumaturge.item.ModItems;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
@@ -15,13 +18,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.Optional;
 
+@Environment(EnvType.CLIENT)
 @Mixin(ItemStack.class)
 public abstract class ItemStackClientMixin {
 
     @Inject(method = "getTooltipData", at = @At("HEAD"), cancellable = true)
     private void addAspectTooltipData(CallbackInfoReturnable<Optional<TooltipData>> cir) {
         ItemStack stack = (ItemStack) (Object) this;
-        AspectComponent component = stack.getOrDefault(AspectComponent.TYPE, AspectComponent.DEFAULT);
+        AspectComponent component = stack.getOrDefault(ModComponents.ASPECT, AspectComponent.DEFAULT);
         if (component == null || component.getAspects().isEmpty()) {
             return;
         }

--- a/src/main/java/dev/overgrown/thaumaturge/predicate/component/BookStatePredicate.java
+++ b/src/main/java/dev/overgrown/thaumaturge/predicate/component/BookStatePredicate.java
@@ -1,0 +1,34 @@
+package dev.overgrown.thaumaturge.predicate.component;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.overgrown.thaumaturge.component.BookStateComponent;
+import dev.overgrown.thaumaturge.component.ModComponents;
+import net.minecraft.component.ComponentsAccess;
+import net.minecraft.predicate.component.ComponentPredicate;
+
+/**
+	This component predicate check the {@link BookStateComponent} properties of an item stack
+ */
+public record BookStatePredicate(boolean open) implements ComponentPredicate {
+
+	public static final Codec<BookStatePredicate> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+		Codec.BOOL.fieldOf("open").forGetter(BookStatePredicate::open)
+	).apply(instance, BookStatePredicate::new));
+
+	@Override
+	public boolean test(ComponentsAccess components) {
+
+		BookStateComponent bookStateComponent = components.get(ModComponents.BOOK_STATE);
+
+		if (bookStateComponent != null) {
+			return bookStateComponent.open() == this.open();
+		}
+
+		else {
+			return false;
+		}
+
+	}
+
+}

--- a/src/main/java/dev/overgrown/thaumaturge/predicate/component/ModComponentPredicateTypes.java
+++ b/src/main/java/dev/overgrown/thaumaturge/predicate/component/ModComponentPredicateTypes.java
@@ -1,0 +1,21 @@
+package dev.overgrown.thaumaturge.predicate.component;
+
+import com.mojang.serialization.Codec;
+import dev.overgrown.thaumaturge.Thaumaturge;
+import net.minecraft.predicate.component.ComponentPredicate;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+
+public class ModComponentPredicateTypes {
+
+	public static final ComponentPredicate.Type<BookStatePredicate> BOOK_STATE = register("book_state", BookStatePredicate.CODEC);
+
+	public static void register() {
+
+	}
+
+	private static <T extends ComponentPredicate> ComponentPredicate.Type<T> register(String path, Codec<T> codec) {
+		return Registry.register(Registries.DATA_COMPONENT_PREDICATE_TYPE, Thaumaturge.identifier(path), new ComponentPredicate.Type<>(codec));
+	}
+
+}

--- a/src/main/resources/assets/thaumaturge/items/apophenia.json
+++ b/src/main/resources/assets/thaumaturge/items/apophenia.json
@@ -1,17 +1,19 @@
 {
-  "model": {
-    "type": "minecraft:condition",
-    "property": "minecraft:component",
-    "predicate": "minecraft:custom_data",
-    "value": "{is_open:1b}",
-    "on_true": {
-      "type": "minecraft:model",
-      "model": "thaumaturge:item/apophenia_open"
-    },
-    "on_false": {
-      "type": "minecraft:model",
-      "model": "thaumaturge:item/apophenia_closed"
-    }
-  },
-  "hand_animation_on_swap": true
+	"model": {
+		"type": "minecraft:condition",
+		"property": "minecraft:component",
+		"predicate": "thaumaturge:book_state",
+		"value": {
+			"open": true
+		},
+		"on_true": {
+			"type": "minecraft:model",
+			"model": "thaumaturge:item/apophenia_open"
+		},
+		"on_false": {
+			"type": "minecraft:model",
+			"model": "thaumaturge:item/apophenia_closed"
+		}
+	},
+	"hand_animation_on_swap": true
 }

--- a/src/main/resources/thaumaturge.mixins.json
+++ b/src/main/resources/thaumaturge.mixins.json
@@ -3,7 +3,9 @@
   "package": "dev.overgrown.thaumaturge.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "ItemMixin",
+    "ItemMixin"
+  ],
+  "client": [
     "client.ItemStackClientMixin"
   ],
   "injectors": {


### PR DESCRIPTION
* Moved the type for the `aspect` item component in the `ModComponents` class
* The `book_state` item component now uses its own class (which is a record that currently only has an `open` property)
* Added a `book_state` component predicate type which can check for the properties of the `book_state` item component