### PR TITLE
Fix potentia laser beam

### DIFF
--- a/src/main/java/dev/overgrown/thaumaturge/spell/SpellHandler.java
+++ b/src/main/java/dev/overgrown/thaumaturge/spell/SpellHandler.java
@@ -41,7 +41,16 @@ public class SpellHandler {
             // Create and shoot the spell bolt
             SpellBoltEntity bolt = new SpellBoltEntity(ModEntities.SPELL_BOLT, player.getWorld());
             bolt.setCaster(player);
-            bolt.setPosition(player.getEyePos());
+
+            // Hitbox at the middle of the lightning
+            Vec3d hitbox = player.getEyePos().add(player.getRotationVector().multiply(SpellBoltEntity.LENGTH / 2));
+
+            bolt.setPosition(hitbox);
+
+            bolt.setYaw(player.getHeadYaw());
+            bolt.setPitch(player.getPitch());
+
+            /*
             Vec3d direction = player.getRotationVector().normalize();
             Vec3d spawnPos = player.getEyePos().add(direction.multiply(0.2));
             bolt.setPosition(spawnPos);
@@ -52,6 +61,7 @@ public class SpellHandler {
             );
             bolt.setVelocity(direction.multiply(1.5));
             ProjectileUtil.setRotationFromVelocity(bolt, 1.0f);
+             */
             bolt.setTier(tier.ordinal());
 
             // Collect effects from other aspects and modifiers
@@ -120,7 +130,7 @@ public class SpellHandler {
                 GauntletComponent component = stack.get(ModComponents.GAUNTLET_STATE);
                 if (component != null) {
                     entries.addAll(component.entries().stream()
-                            .filter(e -> e.tier() == tier)
+                            // TODO: .filter(e -> e.tier().equals(tier))
                             .toList());
                 }
             }

--- a/src/main/java/dev/overgrown/thaumaturge/spell/impl/potentia/render/SpellBoltRenderer.java
+++ b/src/main/java/dev/overgrown/thaumaturge/spell/impl/potentia/render/SpellBoltRenderer.java
@@ -39,8 +39,14 @@ public class SpellBoltRenderer extends EntityRenderer<SpellBoltEntity, SpellBolt
     @Override
     public void render(SpellBoltRenderState state, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light) {
         matrices.push();
-        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(state.yaw + 180.0F));
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(-state.yaw));
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(state.pitch));
+
+        // Move beam little bit to the right
+        matrices.translate(-0.2, -0.2, 0);
+        matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(3));
+        matrices.multiply(RotationAxis.NEGATIVE_X.rotationDegrees(3));
+
         renderBolt(matrices, vertexConsumers, state.tier, state.seed);
         matrices.pop();
     }
@@ -60,15 +66,16 @@ public class SpellBoltRenderer extends EntityRenderer<SpellBoltEntity, SpellBolt
     }
 
     private void generateBranch(Matrix4f matrix, VertexConsumer consumer, Random random, float r, float g, float b, float alpha) {
-        int segments = 8;
-        float segmentLength = 0.5f;
+
+        int segments = (int) SpellBoltEntity.LENGTH;
+        float segmentLength = 1f;
         float spread = 0.35f;
 
         float prevX = 0;
         float prevY = 0;
         float prevZ = 0;
 
-        for (int i = 0; i < segments; i++) {
+        for (int i = -segments/2; i < segments/2; i++) {
             // Move forward in local Z axis (bolt's direction)
             float z = i * segmentLength;
 
@@ -76,13 +83,12 @@ public class SpellBoltRenderer extends EntityRenderer<SpellBoltEntity, SpellBolt
             float x = (random.nextFloat() - 0.5f) * spread;
             float y = (random.nextFloat() - 0.5f) * spread;
 
-            if (i > 0) {
                 // Draw line from previous point to current
                 consumer.vertex(matrix, prevX, prevY, prevZ)
                         .color(r, g, b, alpha);
                 consumer.vertex(matrix, x, y, z)
                         .color(r, g, b, alpha);
-            }
+
 
             prevX = x;
             prevY = y;


### PR DESCRIPTION
My take on potentia laser beam.
- Fix wrong laser rotation
- Make slight offset to show its being shot from the gauntlet
- Implement entity collision detection

Few notes:
- Right now laser simply damages entities
- Entity collision visualized using particles, those should probably be removed
- I didn't use velocity parameter which originally was used heavily
- A lot of code is commented out - didn't want to remove it
- I discovered a bug(?) where gauntlet tier has to be equal to focus tier - it was the reason some gauntlet/foci combinations didn't work for me. Marked with `TODO`