### PR TITLE
Fixed "No data fixer registered for thaumaturge:spell_bolt" error

### DIFF
--- a/src/main/java/dev/overgrown/thaumaturge/registry/ModEntities.java
+++ b/src/main/java/dev/overgrown/thaumaturge/registry/ModEntities.java
@@ -14,6 +14,7 @@ public class ModEntities {
                     Thaumaturge.identifier("spell_bolt"),
                     EntityType.Builder.create(SpellBoltEntity::new, SpawnGroup.MISC)
                             .setDimensions(0.5f, 0.5f)
+                            .disableSaving()
                             .build(Thaumaturge.identifier("spell_bolt").toString())
             );
 }


### PR DESCRIPTION
Whenever I launched the game I saw a `[Render thread/ERROR] (Minecraft) No data fixer registered for thaumaturge:spell_bolt` error in the console.

The error occurs because Minecraft's data fixer system doesn't recognize the custom `thaumaturge:spell_bolt` entity. This happens when an entity is saved to disk but doesn't have a corresponding data fixer for version changes. I disabled saving for the entity since `SpellBoltEntity` is a short-lived projectile, so disabling saving, prevents the data version issue:
```java
// In ModEntities.java
public static final EntityType<SpellBoltEntity> SPELL_BOLT =
        Registry.register(
                Registries.ENTITY_TYPE,
                Thaumaturge.identifier("spell_bolt"),
                EntityType.Builder.create(SpellBoltEntity::new, SpawnGroup.MISC)
                        .setDimensions(0.5f, 0.5f)
                        .disableSaving() // Added this line
                        .build(Thaumaturge.identifier("spell_bolt").toString())
        );
```
This makes sure the entity is properly synced between client and server without persistent storage needs.